### PR TITLE
change button label

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = class ViewRaw extends Plugin {
                 React.createElement(Menu.MenuGroup, null, React.createElement(Menu.MenuItem, {
                     action: () => open(() => React.createElement(Modal, { message: args[0].message })),
                     id: 'view-raw',
-                    label: 'View raw'
+                    label: 'View Raw'
                 })
             ))
 


### PR DESCRIPTION
All other buttons on right-click use `Title Case`, well as this plugin uses` Sentence case`, making for an inconsistency.
![image](https://user-images.githubusercontent.com/39217836/93712938-cd631680-fb50-11ea-9ff0-c4a3be48e5c5.png)