### PR TITLE
Make zero-width-spaces detectable

### DIFF
--- a/Modal.jsx
+++ b/Modal.jsx
@@ -3,13 +3,43 @@ const { FormTitle } = require('powercord/components')
 const { Modal } = require('powercord/components/modal')
 const { close } = require('powercord/modal')
 
+const ZWS = '\u200B'
+const ZWS_RE = /\u200B|\u200C|\u200D|\u2060|\u180E/
+
+function strToReact (str) {
+    const zws = <span className='zws'>{ZWS}</span>
+    return str.split(ZWS_RE).reduce((r, a) => r.concat(zws, a), []).slice(1)
+}
+
+function parseContent (content) {
+    const res = getModule(['parse', 'parseTopic'], false).defaultRules.codeBlock
+        .react({ content }, null, {})
+    const ogRender = res.props.render
+    res.props.render = (codeblock) => {
+        const res = ogRender(codeblock)
+        if (typeof res.props.children.props.children === 'string') {
+            res.props.children.props.children = strToReact(res.props.children.props.children)
+        } else {
+            const props = res.props.children.props.children.props.children[1].props
+            if (Array.isArray(props.children)) {
+                props.children = props.children.forEach(c => {
+                    c.props.children[1].props.children = strToReact(c.props.children[1].props.children)
+                })
+            } else {
+                props.children.props.children[1].props.children = strToReact(props.children.props.children[1].props.children)
+            }
+        }
+        return res
+    }
+    return res
+}
+
 module.exports = ({ message }) => <Modal size={ Modal.Sizes.MEDIUM } className='vrmodal'>
     <Modal.Header>
-        <FormTitle tag='h3'>Raw message written by { message.author.username }</FormTitle>
+        <FormTitle tag='h4'>Raw message written by { message.author.username }</FormTitle>
         <Modal.CloseButton onClick={ close } />
     </Modal.Header>
     <Modal.Content className={ getModule(['markup'], false).markup }>
-        { getModule(['parse', 'parseTopic'], false).defaultRules.codeBlock
-            .react({ content: message.content }, null, {}) }
+        { parseContent(message.content) }
     </Modal.Content>
 </Modal>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { resolve } = require('path')
 const { Plugin } = require('powercord/entities')
 const { findInReactTree } = require('powercord/util')
 const { getModule, React } = require('powercord/webpack')
@@ -9,7 +8,7 @@ const Modal = require('./Modal')
 
 module.exports = class ViewRaw extends Plugin {
     async startPlugin() {
-        this.loadCSS(resolve(__dirname, 'style.css'))
+        this.loadStylesheet('style.css')
 
         const Menu = await getModule(['MenuGroup', 'MenuItem'])
         const MessageContextMenu = await getModule(m => m.default && m.default.displayName == 'MessageContextMenu')

--- a/style.css
+++ b/style.css
@@ -10,9 +10,7 @@
 }
 
 .vrmodal .zws {
-    position: relative;
-    display: inline-block;
     width: 1px;
-    margin-bottom: -5px;
+    display: inline-block;
     background-color: #f00;
 }

--- a/style.css
+++ b/style.css
@@ -8,3 +8,11 @@
 .vrmodal .defaultMarginh3-2iptLs{
     margin-bottom: 0;
 }
+
+.vrmodal .zws {
+    position: relative;
+    display: inline-block;
+    width: 1px;
+    margin-bottom: -5px;
+    background-color: #f00;
+}


### PR DESCRIPTION
Also improved the modal header to match Discord's design more closely. Compatible with or without `pc-codeblocks`, so people who disabled it (who????) won't experience breakage.

![image](https://user-images.githubusercontent.com/9999055/93719047-64939280-fb80-11ea-9c45-affd3ea1345a.png)
