### PR TITLE
Fix patch in context menu from latest Canary update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
     "name": "View Raw",
     "description": "View & Copy raw message (and markdown) in modal.",
     "author": "Juby210#0577",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "license": "MIT"
 }


### PR DESCRIPTION
This PR injects into the lazyLoadModule, which makes it possible to intercept the loading of the desired module for the subsequent menu injection in the normal mode